### PR TITLE
Add ethtool package

### DIFF
--- a/rootfs/make_rootfs.sh
+++ b/rootfs/make_rootfs.sh
@@ -287,7 +287,7 @@ locale-gen en_US.UTF-8
 $ADDPPACMD
 apt-get -y update
 apt-get -y install dosfstools curl xz-utils iw rfkill wpasupplicant openssh-server alsa-utils \
-	nano git build-essential vim jq $EXTRADEBS
+	nano git build-essential vim jq ethtool $EXTRADEBS
 apt-get -y remove --purge ureadahead
 apt-get -y update
 adduser --gecos $DEBUSER --disabled-login $DEBUSER --uid 1000


### PR DESCRIPTION
The ethtool package should be included in the base package set as it allows for the ethernet settings to be managed. This is important particularly if something similar to the GbE compatibility issue arises, as you can't install ethtool in order to connect to the network!! Also adding as tkaiser requested it on the IRC ;)