### PR TITLE
Change 'auto eth0' to 'allow-hotplug eth0'

### DIFF
--- a/package/root/etc/network/interfaces.d/eth0
+++ b/package/root/etc/network/interfaces.d/eth0
@@ -1,2 +1,2 @@
-auto eth0
+allow-hotplug eth0
 iface eth0 inet dhcp


### PR DESCRIPTION
Using 'auto' is fine in situations where you have a server, and want it to acquire a DHCP address at boot. But it adds an unnecessary (2-5 minute ??) delay to boot if the ethernet cable is not plugged in, so is not suited to use cases where networking is not used, or wireless is used instead. allow-hotplug will trigger when the cable is connected, allowing for auto-negotiation at boot if the cable is present.