### PR TITLE
Ethernet stats monitor

### DIFF
--- a/package/root/usr/local/sbin/rock64_eth0_stats.sh
+++ b/package/root/usr/local/sbin/rock64_eth0_stats.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ "$(id -u)" -ne "0" ]; then
-        echo "This script requires root."
-        exit 1
-fi
-
 print() {
         printf "%-20s: %s %s\n" "$1" "$2 $3" "$4"
 }

--- a/package/root/usr/local/sbin/rock64_eth0_stats.sh
+++ b/package/root/usr/local/sbin/rock64_eth0_stats.sh
@@ -2,12 +2,13 @@
 
 set -e
 
+STAT_PATH=/sys/bus/platform/drivers/rk_gmac-dwmac/ff540000.eth/net/eth0/statistics
+
 print() {
         printf "%-20s: %s %s\n" "$1" "$2 $3" "$4"
 }
 
 statprint() {
-	local STAT_PATH=/sys/bus/platform/drivers/rk_gmac-dwmac/ff540000.eth/net/eth0/statistics
 	local STAT_VALUE=$(cat $STAT_PATH/$1)
 	print "$1" $STAT_VALUE
 }

--- a/package/root/usr/local/sbin/rock64_eth0_stats.sh
+++ b/package/root/usr/local/sbin/rock64_eth0_stats.sh
@@ -40,30 +40,35 @@ all() {
 }
 
 usage() {
-	echo "Usage: $0 [-w] [-h]"
+	echo "Usage: $0 [OPTION]"
+        echo -e "  -w [time]\tKeep watching, refreshing every 0.5 seconds or as set"
+        echo -e "  -h\t\tThis help screen"
 }
 
-WATCH=""
-for i in "$@"; do
-	case $i in
-	-w)
-		WATCH=1
-		shift
-		;;
-	-h|--help)
-		usage
-		exit 0
-		;;
-	*)
-		usage
-		exit 1
-		;;
-	esac
+while getopts ":w:h" opt; do
+   case $opt in
+      w)
+         if [[ $OPTARG =~ ^[0-9]+$ ]]; then
+           WATCH=$OPTARG
+         fi
+         ;;
+      h)
+         usage
+         exit 0
+         ;;
+      :) #can only be -w with no custom refresh interval
+         WATCH=0.5
+         ;;
+      *)
+         echo "Invalid parameter '-$OPTARG'"
+         usage
+         exit 1
+         ;;
+   esac
 done
 
 if [ -n "$WATCH" ]; then
-	exec watch -n0.5 "$0"
+	exec watch -n$WATCH "$0"
 else
 	all
 fi
-

--- a/package/root/usr/local/sbin/rock64_eth0_stats.sh
+++ b/package/root/usr/local/sbin/rock64_eth0_stats.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -e
+
+if [ "$(id -u)" -ne "0" ]; then
+        echo "This script requires root."
+        exit 1
+fi
+
+print() {
+        printf "%-20s: %s %s\n" "$1" "$2 $3" "$4"
+}
+
+statprint() {
+	local STAT_PATH=/sys/bus/platform/drivers/rk_gmac-dwmac/ff540000.eth/net/eth0/statistics
+	local STAT_VALUE=$(cat $STAT_PATH/$1)
+	print "$1" $STAT_VALUE
+}
+
+all() {
+	statprint collisions
+	statprint multicast
+	statprint rx_bytes
+	statprint rx_compressed
+	statprint rx_crc_errors
+	statprint rx_dropped
+	statprint rx_errors
+	statprint rx_fifo_errors
+	statprint rx_frame_errors
+	statprint rx_length_errors
+	statprint rx_missed_errors
+	statprint rx_over_errors
+	statprint rx_packets
+	statprint tx_aborted_errors
+	statprint tx_bytes
+	statprint tx_carrier_errors
+	statprint tx_compressed
+	statprint tx_dropped
+	statprint tx_errors
+	statprint tx_fifo_errors
+	statprint tx_heartbeat_errors
+	statprint tx_packets
+	statprint tx_window_errors
+}
+
+usage() {
+	echo "Usage: $0 [-w] [-h]"
+}
+
+WATCH=""
+for i in "$@"; do
+	case $i in
+	-w)
+		WATCH=1
+		shift
+		;;
+	-h|--help)
+		usage
+		exit 0
+		;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+done
+
+if [ -n "$WATCH" ]; then
+	exec watch -n0.5 "$0"
+else
+	all
+fi
+


### PR DESCRIPTION
I've done this as a separate branch/PR so you don't have to cherrypick commits. I was knocking around in the sysfs space and came across ethernet stats, and though it might be useful. If it's now that interesting, it's in my scripts repo anyway.

Displays information from the ethernet statistics sys path.
Formatting and display code based on rock64_health.sh origins.