### PR TITLE
Added parameter for block device to resize_rootfs script

### DIFF
--- a/package/root/usr/local/sbin/resize_rootfs.sh
+++ b/package/root/usr/local/sbin/resize_rootfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]; then
+if [ $# -ne 1 ]; then
 	echo "No arguments provided... please specify device to resize!"
 	echo "e.g. $(basename $0) /dev/mmcblk1"
 	exit 1
@@ -18,7 +18,7 @@ fi
 
 set -xe
 
-gdisk $1 <<EOF
+gdisk "$1" <<EOF
 x
 e
 m
@@ -36,6 +36,6 @@ w
 Y
 EOF
 
-partprobe $1
+partprobe "$1"
 
-resize2fs $1p7
+resize2fs "${1}p7"

--- a/package/root/usr/local/sbin/resize_rootfs.sh
+++ b/package/root/usr/local/sbin/resize_rootfs.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 
-set -xe
+if [ $# -eq 0 ]; then
+	echo "No arguments provided... please specify device to resize!"
+	echo "e.g. $(basename $0) /dev/mmcblk1"
+	exit 1
+fi
+
+if [ ! -b "$1" ]; then
+	echo "Specified device '$1' does not exist! Abort!"
+	exit 1
+fi
 
 if [ "$(id -u)" -ne "0" ]; then
 	echo "This script requires root."
 	exit 1
 fi
 
-gdisk /dev/mmcblk0 <<EOF
+set -xe
+
+gdisk $1 <<EOF
 x
 e
 m
@@ -25,6 +36,6 @@ w
 Y
 EOF
 
-partprobe /dev/mmcblk0
+partprobe $1
 
-resize2fs /dev/mmcblk0p7
+resize2fs $1p7


### PR DESCRIPTION
Now requires device to be resized to be specified, allowing the script to be used for resizing SD card or eMMC, and does a simple check that the specified block device exists. Also moved command echoing to start below the initial argument check, block device and root privileges checks.