### PR TITLE
Jenkinsfile improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node('docker && linux-build') {
                 sh '''#!/bin/bash
                   set +xe
                   export CCACHE_DIR=$WORKSPACE/ccache
-                  make -j$(nproc)
+                  make -j$(nproc) $MAKE_TARGET
                 '''
               }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('docker && linux-build') {
                 '''
               }
 
-              stage 'Sources' {
+              stage('Sources') {
                 sh '''#!/bin/bash
                   set -xe
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,116 +13,124 @@ properties([
 node('docker && linux-build') {
   timestamps {
     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
-      stage "Environment"
-      checkout scm
+      stage('Environment') {
+        checkout scm
 
-      def environment = docker.build('build-environment:build-rock64-image', 'environment')
+        def environment = docker.build('build-environment:build-rock64-image', 'environment')
 
-      environment.inside("--privileged -u 0:0") {
-        withEnv([
-          "USE_CCACHE=true",
-          "RELEASE_NAME=$VERSION",
-          "RELEASE=$BUILD_NUMBER"
-        ]) {
-            stage 'Prepare'
-            sh '''#!/bin/bash
-              set +xe
-              export CCACHE_DIR=$WORKSPACE/ccache
-              ccache -M 0 -F 0
-              git clean -ffdx -e ccache
-            '''
+        environment.inside("--privileged -u 0:0") {
+          withEnv([
+            "USE_CCACHE=true",
+            "RELEASE_NAME=$VERSION",
+            "RELEASE=$BUILD_NUMBER"
+          ]) {
+              stage('Prepare') {
+                sh '''#!/bin/bash
+                  set +xe
+                  export CCACHE_DIR=$WORKSPACE/ccache
+                  ccache -M 0 -F 0
+                  git clean -ffdx -e ccache
+                '''
+              }
 
-            stage 'Sources'
-            sh '''#!/bin/bash
-              set -xe
+              stage 'Sources' {
+                sh '''#!/bin/bash
+                  set -xe
 
-              export HOME=$WORKSPACE
-              export USER=jenkins
+                  export HOME=$WORKSPACE
+                  export USER=jenkins
 
-              repo init -u https://github.com/ayufan-rock64/linux-manifests -b default --depth=1
+                  repo init -u https://github.com/ayufan-rock64/linux-manifests -b default --depth=1
 
-              repo sync -j 20 -c --force-sync
-            '''
+                  repo sync -j 20 -c --force-sync
+                '''
+              }
 
-            stage 'U-boot'
-            sh '''#!/bin/bash
-              set +xe
-              export CCACHE_DIR=$WORKSPACE/ccache
-              make u-boot
-            '''
+              stage('U-boot') {
+                sh '''#!/bin/bash
+                  set +xe
+                  export CCACHE_DIR=$WORKSPACE/ccache
+                  make u-boot
+                '''
+              }
 
-            stage 'Kernel'
-            sh '''#!/bin/bash
-              set +xe
-              export CCACHE_DIR=$WORKSPACE/ccache
-              make kernel
-            '''
+              stage('Kernel') {
+                sh '''#!/bin/bash
+                  set +xe
+                  export CCACHE_DIR=$WORKSPACE/ccache
+                  make kernel
+                '''
+              }
 
-            stage 'Images'
-            sh '''#!/bin/bash
-              set +xe
-              export CCACHE_DIR=$WORKSPACE/ccache
-              make -j$(nproc)
-            '''
-        }
-  
-        withEnv([
-          "VERSION=$VERSION",
-          "CHANGES=$CHANGES",
-          "PRERELEASE=$PRERELEASE",
-          "GITHUB_USER=$GITHUB_USER",
-          "GITHUB_REPO=$GITHUB_REPO"
-        ]) {
-          stage 'Freeze'
-          sh '''#!/bin/bash
-            # use -ve, otherwise we could leak GITHUB_TOKEN...
-            set -ve
-            shopt -s nullglob
+              stage('Images') {
+                sh '''#!/bin/bash
+                  set +xe
+                  export CCACHE_DIR=$WORKSPACE/ccache
+                  make -j$(nproc)
+                '''
+              }
+          }
 
-            export HOME=$WORKSPACE
-            export USER=jenkins
+          withEnv([
+            "VERSION=$VERSION",
+            "CHANGES=$CHANGES",
+            "PRERELEASE=$PRERELEASE",
+            "GITHUB_USER=$GITHUB_USER",
+            "GITHUB_REPO=$GITHUB_REPO"
+          ]) {
+            stage('Freeze') {
+              sh '''#!/bin/bash
+                # use -ve, otherwise we could leak GITHUB_TOKEN...
+                set -ve
+                shopt -s nullglob
 
-            repo manifest -r -o manifest.xml
-          '''
+                export HOME=$WORKSPACE
+                export USER=jenkins
 
-          stage 'Release'
-          sh '''#!/bin/bash
-            set -xe
-            shopt -s nullglob
+                repo manifest -r -o manifest.xml
+              '''
+            }
 
-            github-release release \
-                --tag "${VERSION}" \
-                --name "$VERSION: $BUILD_TAG" \
-                --description "${CHANGES}\n\n${BUILD_URL}" \
-                --draft
+            stage('Release') {
+              sh '''#!/bin/bash
+                set -xe
+                shopt -s nullglob
 
-            github-release upload \
-                --tag "${VERSION}" \
-                --name "manifest.xml" \
-                --file "manifest.xml"
+                github-release release \
+                    --tag "${VERSION}" \
+                    --name "$VERSION: $BUILD_TAG" \
+                    --description "${CHANGES}\n\n${BUILD_URL}" \
+                    --draft
 
-            for file in *.xz *.deb; do
-              github-release upload \
-                  --tag "${VERSION}" \
-                  --name "$(basename "$file")" \
-                  --file "$file" &
-            done
+                github-release upload \
+                    --tag "${VERSION}" \
+                    --name "manifest.xml" \
+                    --file "manifest.xml"
 
-            wait
+                for file in *.xz *.deb; do
+                  github-release upload \
+                      --tag "${VERSION}" \
+                      --name "$(basename "$file")" \
+                      --file "$file" &
+                done
 
-            if [[ "$PRERELEASE" == "true" ]]; then
-              github-release edit \
-                --tag "${VERSION}" \
-                --name "$VERSION: $BUILD_TAG" \
-                --description "${CHANGES}\n\n${BUILD_URL}" \
-                --pre-release
-            else
-              github-release edit \
-                --tag "${VERSION}" \
-                --name "$VERSION: $BUILD_TAG" \
-                --description "${CHANGES}\n\n${BUILD_URL}"
-            fi
-          '''
+                wait
+
+                if [[ "$PRERELEASE" == "true" ]]; then
+                  github-release edit \
+                    --tag "${VERSION}" \
+                    --name "$VERSION: $BUILD_TAG" \
+                    --description "${CHANGES}\n\n${BUILD_URL}" \
+                    --pre-release
+                else
+                  github-release edit \
+                    --tag "${VERSION}" \
+                    --name "$VERSION: $BUILD_TAG" \
+                    --description "${CHANGES}\n\n${BUILD_URL}"
+                fi
+              '''
+            }
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ properties([
     text(defaultValue: '', description: 'A list of changes', name: 'CHANGES'),
     choice(choices: 'all\njessie-minimal-rock64\njessie-openmediavault-rock64\nstretch-minimal-rock64\nxenial-i3-rock64\nxenial-mate-rock64\nxenial-minimal-rock64\nlinux-virtual', description: 'What makefile image to target', name: 'MAKE_TARGET')
     booleanParam(defaultValue: true, description: 'Whether to upload to Github for release or not', name: 'GITHUB_UPLOAD'),
-    booleanParam(defaultValue: false, description: 'If build should be marked as pre-release', name: 'PRERELEASE'),
+    booleanParam(defaultValue: false, description: 'If build should be marked as pre-release', name: 'GITHUB_PRERELEASE'),
     string(defaultValue: 'ayufan-rock64', description: 'GitHub username or organization', name: 'GITHUB_USER'),
     string(defaultValue: 'linux-build', description: 'GitHub repository', name: 'GITHUB_REPO'),
   ])
@@ -76,7 +76,7 @@ node('docker && linux-build') {
           withEnv([
             "VERSION=$VERSION",
             "CHANGES=$CHANGES",
-            "PRERELEASE=$PRERELEASE",
+            "GITHUB_PRERELEASE=$GITHUB_PRERELEASE",
             "GITHUB_USER=$GITHUB_USER",
             "GITHUB_REPO=$GITHUB_REPO"
           ]) {
@@ -119,7 +119,7 @@ node('docker && linux-build') {
 
                   wait
 
-                  if [[ "$PRERELEASE" == "true" ]]; then
+                  if [[ "$GITHUB_PRERELEASE" == "true" ]]; then
                     github-release edit \
                       --tag "${VERSION}" \
                       --name "$VERSION: $BUILD_TAG" \


### PR DESCRIPTION
Changes to the jenkinsfile to 
a) remove deprecation warnings in the logs re: stage 
b) allow upload of releases to be optional
c) allow specific makefile target to be compiled

NOTE: I changed PRERELEASE to GITHUB_PRERELEASE to be consistent with your pine64 Jenkinsfile. That should the be only changed _needed_ on your end by this PR. 

I may or may not have tested it ;)

https://github.com/pfeerick-rock64/linux-build/releases/tag/0.4.4-jenkinsfile-improvements

![image](https://user-images.githubusercontent.com/5500713/28498148-28da3d4a-6fdb-11e7-93ff-ce6e7cd91e54.png)
