### PR TITLE
Changes based on tkaiser feedback on OMV

### DIFF
--- a/package/root/usr/local/sbin/rock64_diagnostics.sh
+++ b/package/root/usr/local/sbin/rock64_diagnostics.sh
@@ -280,7 +280,7 @@ UploadSupportLogs() {
 	which iostat >/dev/null 2>&1 || MissingTools="${MissingTools} sysstat"
 
 	if [ "X${MissingTools}" != "X" ]; then
-		echo -e "Some tools are missing, installing: \c ${MissingTools}" >&2
+		echo -e "Some tools are missing, installing: ${MissingTools}" >&2
 		apt-get -f -qq -y install ${MissingTools} >/dev/null 2>&1
 	fi
 


### PR DESCRIPTION
Added extra exclusions for verify/repair mode. Changed wording of fix/verify
messages to be a bit less scary. Removed a leftover pine64 reference. Prevent
colour escape making it into the uploaded support log.
https://github.com/pfeerick/pine64-scripts/commit/feec9d3b6440d72c4b449d487e0ce2a46fb69f82