### PR TITLE
Fix path validation

### DIFF
--- a/build/flash_tool.sh
+++ b/build/flash_tool.sh
@@ -35,7 +35,7 @@ while getopts "c:t:s:d:p:r:d:i:h" flag; do
 			;;
 		i)
 			IMAGE="$OPTARG"
-			if [ ! -e "${IMAGE}" ]; then
+			if [ ! -f "${IMAGE}" ]; then
 				echo -e "\e[31m CAN'T FIND IMAGE \e[0m"
 				usage
 				exit
@@ -62,7 +62,7 @@ if [ ! $IMAGE ]; then
 	exit
 fi
 
-if [ ! -e "${EXTLINUXPATH}/${CHIP}.conf" ]; then
+if [ ! -f "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 

--- a/build/flash_tool.sh
+++ b/build/flash_tool.sh
@@ -35,7 +35,7 @@ while getopts "c:t:s:d:p:r:d:i:h" flag; do
 			;;
 		i)
 			IMAGE="$OPTARG"
-			if [ ! -e ${IMAGE} ]; then
+			if [ ! -e "${IMAGE}" ]; then
 				echo -e "\e[31m CAN'T FIND IMAGE \e[0m"
 				usage
 				exit
@@ -62,7 +62,7 @@ if [ ! $IMAGE ]; then
 	exit
 fi
 
-if [ ! -e ${EXTLINUXPATH}/${CHIP}.conf ]; then
+if [ ! -e "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 

--- a/build/mk-image.sh
+++ b/build/mk-image.sh
@@ -80,6 +80,18 @@ generate_boot_image() {
 }
 
 generate_system_image() {
+	if [ ! -e "${BOOT_PATH}" ]; then
+		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
+		usage
+		exit 1
+	fi
+
+	if [ ! -e "${ROOTFS_PATH}" ]; then
+		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
+		usage
+		exit 1
+	fi
+
 	SYSTEM="${OUT_IMAGE}"
 	rm -rf ${SYSTEM}
 
@@ -108,17 +120,9 @@ generate_system_image() {
 	fi
 
 	echo "Burn boot..."
-	if [ ! -e "${BOOT_PATH}" ]; then
-		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
-		exit 1
-	fi
 	dd if=${BOOT_PATH} of=${SYSTEM} seek=${BOOT_START} conv=notrunc status=none
 
 	echo "Burn rootfs..."
-	if [ ! -e "${ROOTFS_PATH}" ]; then
-		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
-		exit 1
-	fi
 	dd if=${ROOTFS_PATH} of=${SYSTEM} seek=${ROOTFS_START} conv=notrunc status=none
 	dd if=/dev/zero of=${SYSTEM} count=2048 oflag=append conv=notrunc
 

--- a/build/mk-image.sh
+++ b/build/mk-image.sh
@@ -54,7 +54,7 @@ while getopts "c:t:s:r:b:o:h" flag; do
 done
 OPTIND=$OLD_OPTIND
 
-if [ ! -e "${EXTLINUXPATH}/${CHIP}.conf" ]; then
+if [ ! -f "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 
@@ -80,13 +80,13 @@ generate_boot_image() {
 }
 
 generate_system_image() {
-	if [ ! -e "${BOOT_PATH}" ]; then
+	if [ ! -f "${BOOT_PATH}" ]; then
 		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
 		usage
 		exit 1
 	fi
 
-	if [ ! -e "${ROOTFS_PATH}" ]; then
+	if [ ! -f "${ROOTFS_PATH}" ]; then
 		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
 		usage
 		exit 1

--- a/build/mk-image.sh
+++ b/build/mk-image.sh
@@ -54,7 +54,7 @@ while getopts "c:t:s:r:b:o:h" flag; do
 done
 OPTIND=$OLD_OPTIND
 
-if [ ! -e ${EXTLINUXPATH}/${CHIP}.conf ]; then
+if [ ! -e "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 
@@ -108,14 +108,14 @@ generate_system_image() {
 	fi
 
 	echo "Burn boot..."
-	if [ ! -e ${BOOT_PATH} ]; then
+	if [ ! -e "${BOOT_PATH}" ]; then
 		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
 		exit 1
 	fi
 	dd if=${BOOT_PATH} of=${SYSTEM} seek=${BOOT_START} conv=notrunc status=none
 
 	echo "Burn rootfs..."
-	if [ ! -e ${ROOTFS_PATH} ]; then
+	if [ ! -e "${ROOTFS_PATH}" ]; then
 		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
 		exit 1
 	fi


### PR DESCRIPTION
Validate paths before starting any work and quote the paths to ensure the conditionals work properly.

For example:
```bash
$ IMAGE=""
$ if [ ! -e $IMAGE ]; then echo 'bad path'; fi
$ if [ ! -e "$IMAGE" ]; then echo 'bad path'; fi
bad path
$ if [ ! -e ${IMAGE} ]; then echo 'bad path'; fi
$ if [ ! -e "${IMAGE}" ]; then echo 'bad path'; fi
bad path
$ if [ ! -f ${IMAGE} ]; then echo 'bad path'; fi
$ if [ ! -f "${IMAGE}" ]; then echo 'bad path'; fi
bad path
```