### PR TITLE
Enable memory and CPU control/metrics via cgroups

### DIFF
--- a/package/root/boot/efi/extlinux/extlinux.conf
+++ b/package/root/boot/efi/extlinux/extlinux.conf
@@ -2,4 +2,4 @@ label kernel-4.4
     kernel /Image
     initrd /initrd.img
     fdt /dtb
-    append earlycon=uart8250,mmio32,0xff130000 rw root=LABEL=linux-root rootwait rootfstype=ext4 init=/sbin/init coherent_pool=1M ethaddr=${ethaddr} eth1addr=${eth1addr} serial=${serial#}
+    append earlycon=uart8250,mmio32,0xff130000 rw root=LABEL=linux-root rootwait rootfstype=ext4 init=/sbin/init coherent_pool=1M ethaddr=${ethaddr} eth1addr=${eth1addr} serial=${serial#} cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1


### PR DESCRIPTION
According to the Wiki, to support memory and CPU control and metrics via cgroups for Docker, the parameters need to be added to kernel boot arguments.
Refs:
https://docs.docker.com/engine/admin/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
https://wiki.debian.org/LXC#Preparing_the_host_system_for_running_LXC