### PR TITLE
Disable ionice related syslog spam every minute

### DIFF
--- a/package/root/etc/rsyslog.d/mute-ionice.conf
+++ b/package/root/etc/rsyslog.d/mute-ionice.conf
@@ -1,0 +1,1 @@
+:msg, contains, "do ionice -c1" ~


### PR DESCRIPTION
This addresses the syslog messages every minute caused by /etc/cron.d/make_nas_processes_faster